### PR TITLE
Add Claude pre-push hooks for clippy and doc checks

### DIFF
--- a/.claude/hooks/pre-push.sh
+++ b/.claude/hooks/pre-push.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Consume stdin (hook protocol)
+cat > /dev/null
+
+cd "$(dirname "$0")/../.."
+
+echo "Running pre-push checks..." >&2
+
+if ! cargo +nightly fmt -- --check 2>&1; then
+    echo "Format check failed. Run 'cargo +nightly fmt' to fix." >&2
+    exit 2
+fi
+
+if ! cargo clippy --workspace --all-targets -- -D warnings 2>&1; then
+    echo "Clippy failed." >&2
+    exit 2
+fi
+
+if ! RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps 2>&1; then
+    echo "Doc check failed." >&2
+    exit 2
+fi
+
+echo "All pre-push checks passed." >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Signet Node
+
+## Versioning
+
+- This repo uses a chain-oriented versioning scheme:
+  `<hard fork>.<configuration>.<patch>`
+- Each binary in the workspace (`signet`, `signet-exex`, `signet-sidecar`)
+  has its own independent version. Configuration changes may affect one binary
+  but not others.
+- When bumping versions, only bump the binary that is actually affected by
+  the change. Do NOT synchronize versions across binaries.
+
+## Commands
+
+- `cargo +nightly fmt` - format
+- `cargo clippy -p <crate> --all-targets` - lint
+- `cargo t -p <crate>` - test specific crate
+
+Pre-push: clippy + fmt. Never use `cargo check/build`.
+
+### Pre-push Checks (enforced by Claude hook)
+
+A Claude hook in `.claude/settings.json` runs `.claude/hooks/pre-push.sh`
+before every `git push`. The push is blocked if any check fails. The checks:
+
+- `cargo +nightly fmt -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
+
+Clippy and doc warnings are hard failures.
+
+## Dependencies
+
+- **signet**: node-components pinned to legacy git tag (0.16 line). Uses reth.
+- **signet-exex**: all node-components deps pinned to the same git tag (0.17+
+  line) because `signet-host-reth` is git-only. Mixing git and crates.io
+  sources for the same repo causes duplicate crate versions. Uses reth.
+- **signet-sidecar**: node-components from crates.io (0.17+ line). No git-only
+  deps, no reth dependency.
+- When updating node-components for exex, pin ALL its deps to the same git
+  tag. Do NOT mix crates.io and git sources for `init4tech/node-components`.
+
+## Tags and Releases
+
+- Use prefixed git tags: `<binary>/v<version>` (e.g., `signet/v1.0.0-rc.9`,
+  `signet-exex/v1.0.0-rc.9`).
+- Each tag gets its own GitHub release, titled `<binary> v<version>`.
+- When only one binary changes, only tag and release that binary.


### PR DESCRIPTION
## Summary

- Adds a Claude Code `PreToolUse` hook that runs before every `git push`
- Runs format check, clippy (with `-D warnings`), and doc build (with `-D warnings`)
- Clippy and rustdoc warnings are hard failures that block the push
- Documents the enforced checks in CLAUDE.md

## Files

- `.claude/hooks/pre-push.sh` — the check script
- `.claude/settings.json` — hook configuration
- `CLAUDE.md` — updated with pre-push checks documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)